### PR TITLE
Do not block app removal and remove unused parts

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -1,21 +1,10 @@
 #!/bin/bash
 
-# Exit on command errors and treat unset variables as an error
-set -eu
-
-# Source YunoHost helpers
-. /usr/share/yunohost/helpers
-
 # Define app
 app=phpsysinfo
 
 # Retrieve app settings
 domain=$(ynh_app_setting_get "$app" domain)
-path=$(ynh_app_setting_get "$app" path)
-admin=$(ynh_app_setting_get "$app" admin)
-is_public=$(ynh_app_setting_get "$app" is_public)
-language=$(ynh_app_setting_get "$app" language)
-display_mode=$(ynh_app_setting_get "$app" display_mode)
 
 # Remove sources
 sudo rm -rf /var/www/$app


### PR DESCRIPTION
The `remove` script should not exit if one if the command failed in order to be sure that everything is removed.

For example, imagine that the installation fails at the middle of the script and that everything has not be created/copied - e.g. NGINX configuration, database. The `remove` script will be nevertheless executed after that in order to clear each thing that the `install` script have created / copied / ... So, it must expect that some thing doesn't exist and just continue instead of exiting.
