### PR TITLE
Update manifest.toml

### DIFF
--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,3 +1,3 @@
 ## Configuration
 
-Edit `phpsysinfo.ini` in `/var/www/YOURPATH/phpsysinfo.ini`.
+Edit `phpsysinfo.ini` in `__INSTALL_DIR__/phpsysinfo.ini`.

--- a/manifest.toml
+++ b/manifest.toml
@@ -73,4 +73,4 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = ["php8.3-fpm", "php8.3-xml"]
+    packages = ["php8.2-fpm", "php8.2-xml"]

--- a/scripts/install
+++ b/scripts/install
@@ -20,8 +20,6 @@ ynh_config_add_nginx
 ynh_config_add_phpfpm
 
 #=================================================
-# SPECIFIC SETUP
-#=================================================
 # ADD A CONFIGURATION
 #=================================================
 ynh_script_progression "Adding $app's configuration..."

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,17 +26,11 @@ ynh_script_progression "Updating configuration..."
 
 ynh_backup_if_checksum_is_different "$install_dir/phpsysinfo.ini"
 
-# FIXME: this is still supported but the recommendation is now to *always* re-setup the app sources wether or not the upstream sources changed
-if ynh_app_upstream_version_changed
-then
-	ynh_script_progression "Reconfiguring Phpsysinfo..."
+ynh_replace --match="DEFAULT_LANG=\"en\"" --replace="DEFAULT_LANG=\"$language\"" --file="$install_dir/phpsysinfo.ini.new"
+ynh_replace --match="DEFAULT_DISPLAY_MODE=\"auto\"" --replace="DEFAULT_DISPLAY_MODE=\"$display_mode\"" --file="$install_dir/phpsysinfo.ini.new"
 
-	ynh_replace --match="DEFAULT_LANG=\"en\"" --replace="DEFAULT_LANG=\"$language\"" --file="$install_dir/phpsysinfo.ini.new"
-	ynh_replace --match="DEFAULT_DISPLAY_MODE=\"auto\"" --replace="DEFAULT_DISPLAY_MODE=\"$display_mode\"" --file="$install_dir/phpsysinfo.ini.new"
-
-	### Rename phpsysinfo.ini.new in phpsysinfo.ini
-	mv "$install_dir"/phpsysinfo.ini.new "$install_dir"/phpsysinfo.ini
-fi
+### Rename phpsysinfo.ini.new in phpsysinfo.ini
+mv "$install_dir"/phpsysinfo.ini.new "$install_dir"/phpsysinfo.ini
 
 # Recalculate and store the checksum of the file for the next upgrade.
 ynh_store_file_checksum "$install_dir/phpsysinfo.ini"


### PR DESCRIPTION
Add apt ressources for php8.2 fpm and xml.

## Problem

- Phpsysinfo shows only this message :
phpSysInfo requires the simplexml extension to php in order to work properly.

## Solution

- Modify manifest.toml

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
